### PR TITLE
Fixed Angular Spectrum to deal with negative sqrt

### DIFF
--- a/src/unal/od/jdiffraction/cpu/FloatAngularSpectrum.java
+++ b/src/unal/od/jdiffraction/cpu/FloatAngularSpectrum.java
@@ -87,6 +87,9 @@ public class FloatAngularSpectrum extends FloatPropagator {
                 kernelPhase = c1 + j2 * j2 * dfySq;
                 kernelPhase *= lambdaSq;
                 kernelPhase = 1 - kernelPhase;
+                if (kernelPhase < 0) {
+                    kernelPhase = 0;
+                }
                 kernelPhase = (float) Math.sqrt(kernelPhase);
                 kernelPhase *= kernelFactor;
 
@@ -108,6 +111,9 @@ public class FloatAngularSpectrum extends FloatPropagator {
                 kernelPhase = c1 + j2 * j2 * dfySq;
                 kernelPhase *= lambdaSq;
                 kernelPhase = 1 - kernelPhase;
+                if (kernelPhase < 0) {
+                    kernelPhase = 0;
+                }
                 kernelPhase = (float) Math.sqrt(kernelPhase);
                 kernelPhase *= kernelFactor;
 
@@ -127,6 +133,9 @@ public class FloatAngularSpectrum extends FloatPropagator {
                 kernelPhase = c1 + i2 * i2 * dfxSq;
                 kernelPhase *= lambdaSq;
                 kernelPhase = 1 - kernelPhase;
+                if (kernelPhase < 0) {
+                    kernelPhase = 0;
+                }
                 kernelPhase = (float) Math.sqrt(kernelPhase);
                 kernelPhase *= kernelFactor;
 
@@ -144,6 +153,9 @@ public class FloatAngularSpectrum extends FloatPropagator {
             kernelPhase = i2 * i2 * dfxSq + j2 * j2 * dfySq;
             kernelPhase *= lambdaSq;
             kernelPhase = 1 - kernelPhase;
+            if (kernelPhase < 0) {
+                    kernelPhase = 0;
+                }
             kernelPhase = (float) Math.sqrt(kernelPhase);
             kernelPhase *= kernelFactor;
 


### PR DESCRIPTION
The angular spectrum method didn't work if kernelPhase became negative because of a call to sqrt.  However, according to [this paper](https://pdfs.semanticscholar.org/fe0a/1db2de68aa0d048cedfcd7c44bc626cb5e6a.pdf), if kernelPhase is negative, the value should be zero.  This pull request fixes that problem and makes the value zero when needed.